### PR TITLE
patching GPU Driven rendering

### DIFF
--- a/assets/shaders/aurora/cube.vert.glsl
+++ b/assets/shaders/aurora/cube.vert.glsl
@@ -19,6 +19,10 @@ layout(set = 0, binding = 0) uniform  SceneData{
 	vec4 sunlightColor;
 } scene_data;
 
+layout(set = 1, binding = 0) readonly buffer VertexBuffer2 {
+    vertex_t vertices[];
+} vertex_buffer;
+
 layout(location = 0) out vec3 fragNormal;
 layout(location = 1) out vec2 fragUV;
 
@@ -32,7 +36,7 @@ layout(push_constant) uniform PushConstants {
 } pc;
 
 void main() {
-    vertex_t v = pc.vertex_buffer.vertices[gl_VertexIndex];
+    vertex_t v = vertex_buffer.vertices[gl_VertexIndex];
 
     vec4 position = vec4(v.position, 1.0f);
     gl_Position = scene_data.viewproj * pc.render_matrix * position;

--- a/assets/shaders/aurora/world.comp.glsl
+++ b/assets/shaders/aurora/world.comp.glsl
@@ -56,13 +56,11 @@ void main() {
         }
     }
 
-    if (index == 0) {
-        indexCount = CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE * 36;
-        instanceCount = 1;
-        firstIndex = 0;
-        vertexOffset = 0;
-        firstInstance = 0;
-    }
+    indexCount = CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE * 36;
+    instanceCount = 1;
+    firstIndex = 0;
+    vertexOffset = 0;
+    firstInstance = 0;
 
     // uint vertex_id = gl_GlobalInvocationID.x;
 

--- a/src/engine/graphics/buffers.zig
+++ b/src/engine/graphics/buffers.zig
@@ -51,7 +51,7 @@ pub const GPUMeshBuffers = struct {
             .vertex_buffer = undefined,
             .vertex_buffer_address = undefined,
         };
-        new_surface.vertex_buffer = AllocatedBuffer.init(vma, vertex_buffer_size, c.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | c.VK_BUFFER_USAGE_TRANSFER_DST_BIT | c.VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, c.VMA_MEMORY_USAGE_GPU_ONLY);
+        new_surface.vertex_buffer = AllocatedBuffer.init(vma, vertex_buffer_size, c.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | c.VK_BUFFER_USAGE_TRANSFER_DST_BIT | c.VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | c.VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, c.VMA_MEMORY_USAGE_GPU_ONLY);
 
         const device_adress_info = c.VkBufferDeviceAddressInfo {
             .sType = c.VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,

--- a/src/engine/graphics/compute.zig
+++ b/src/engine/graphics/compute.zig
@@ -93,7 +93,7 @@ pub const Shader = struct {
         self.writer.clear();
         self.writer.write_buffer(0, resources.vertex_buffer, @sizeOf(buffers.Vertex) * cube_vertex_count, resources.vertex_buffer_offset, c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
         self.writer.write_buffer(1, resources.index_buffer, @sizeOf(u32) * cube_index_count, resources.index_buffer_offset, c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-        self.writer.write_buffer(2, resources.index_buffer, @sizeOf(c.VkDrawIndexedIndirectCommand), resources.indirect_buffer_offset, c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        self.writer.write_buffer(2, resources.indirect_buffer, @sizeOf(c.VkDrawIndexedIndirectCommand), resources.indirect_buffer_offset, c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
 
         self.writer.update_set(r._device, data.descriptor);
 

--- a/src/engine/graphics/materials.zig
+++ b/src/engine/graphics/materials.zig
@@ -2,6 +2,8 @@ pub const RenderObject = struct {
     index_count: u32,
     first_index: u32,
     index_buffer: c.VkBuffer,
+    indirect_buffer: c.VkBuffer = null,
+    indirect_buffer_offset: u32 = 0,
 
     material: *MaterialInstance,
 

--- a/src/engine/graphics/materials.zig
+++ b/src/engine/graphics/materials.zig
@@ -2,6 +2,10 @@ pub const RenderObject = struct {
     index_count: u32,
     first_index: u32,
     index_buffer: c.VkBuffer,
+    
+    vertex_buffer: c.VkBuffer = null,
+    vertex_buffer_offset: c.VkDeviceSize = 0,
+
     indirect_buffer: c.VkBuffer = null,
     indirect_buffer_offset: u32 = 0,
 

--- a/src/engine/scene/chunk.zig
+++ b/src/engine/scene/chunk.zig
@@ -132,7 +132,8 @@ pub const Voxel = struct {
             .index_buffer = self.buffer.index_buffer.buffer,
             .material = self.material,
             .transform = za.Mat4.identity().data,
-            .vertex_buffer_address = self.buffer.vertex_buffer_address
+            .vertex_buffer_address = self.buffer.vertex_buffer_address,
+            .indirect_buffer = self.indirect_buffer.buffer,
         };
 
         ctx.opaque_surfaces.append(object) catch {

--- a/src/engine/scene/chunk.zig
+++ b/src/engine/scene/chunk.zig
@@ -41,7 +41,7 @@ pub const Voxel = struct {
         voxel.buffer = buffers.GPUMeshBuffers.init(vma, voxel.indices[0..cube_index_count], voxel.vertices[0..cube_index_count], r);
 
         const resources = Material.Resources {
-            .data_buffer =  voxel.material_buffer.buffer, 
+            .data_buffer =  voxel.buffer.vertex_buffer.buffer, 
             .data_buffer_offset = 0,
         };
 
@@ -132,7 +132,8 @@ pub const Voxel = struct {
             .index_buffer = self.buffer.index_buffer.buffer,
             .material = self.material,
             .transform = za.Mat4.identity().data,
-            .vertex_buffer_address = self.buffer.vertex_buffer_address,
+            .vertex_buffer_address = 0,// self.buffer.vertex_buffer_address,
+            .vertex_buffer = self.buffer.vertex_buffer.buffer,
             .indirect_buffer = self.indirect_buffer.buffer,
         };
 
@@ -141,31 +142,13 @@ pub const Voxel = struct {
         };
     }
 
-    pub fn draw(self: *Voxel, cmd: c.VkCommandBuffer, global_descriptor: c.VkDescriptorSet) void {
-        const constant = buffers.GPUDrawPushConstants{
-            .vertex_buffer = self.buffer.vertex_buffer_address,
-            .world_matrix = za.Mat4.identity().data,
-        };
-
-        c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, self.material.pipeline.pipeline);
-        c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, self.material.pipeline.layout, 0, 1, &global_descriptor, 0, null);
-
-        c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, self.material.pipeline.layout, 1, 1, &self.material.material_set, 0, null);
-
-        c.vkCmdBindIndexBuffer(cmd, self.buffer.index_buffer.buffer, 0, c.VK_INDEX_TYPE_UINT32);
-
-        c.vkCmdPushConstants(cmd, self.material.pipeline.layout, c.VK_SHADER_STAGE_VERTEX_BIT, 0, @sizeOf(buffers.GPUDrawPushConstants), &constant);
-
-        c.vkCmdDrawIndexedIndirect(cmd, self.indirect_buffer.buffer, 0, 1, 0);
-    }
-
     pub fn swap_pipeline(self: *Voxel, allocator: std.mem.Allocator, mat: *Material, r: *const renderer.renderer_t) void {
         // clean old material
         self.arena.allocator().destroy(self.material);
         
         // create new material
         const resources = Material.Resources {
-            .data_buffer = self.material_buffer.buffer, 
+            .data_buffer = self.buffer.vertex_buffer.buffer, 
             .data_buffer_offset = 0,
         };
 
@@ -212,6 +195,8 @@ pub const Material = struct {
         var layout_builder = descriptors.DescriptorLayout.init(allocator);
         defer layout_builder.deinit();
 
+        try layout_builder.add_binding(0, c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER | c.VK_SHADER_STAGE_VERTEX_BIT);
+
         self.layout = layout_builder.build(r._device, c.VK_SHADER_STAGE_VERTEX_BIT | c.VK_SHADER_STAGE_FRAGMENT_BIT, null, 0);
 
         const layouts = [_]c.VkDescriptorSetLayout {
@@ -257,7 +242,7 @@ pub const Material = struct {
         self.pipeline.pipeline = builder.build_pipeline(r._device);
     }
 
-    pub fn write_material(self: *Material, allocator: std.mem.Allocator, device: c.VkDevice, pass: materials.MaterialPass, _: *const Resources, ds_alloc: *descriptors.DescriptorAllocator2)  materials.MaterialInstance {
+    pub fn write_material(self: *Material, allocator: std.mem.Allocator, device: c.VkDevice, pass: materials.MaterialPass, res: *const Resources, ds_alloc: *descriptors.DescriptorAllocator2)  materials.MaterialInstance {
         const data =  materials.MaterialInstance {
             .pass_type = pass,
             .pipeline = &self.pipeline,
@@ -265,7 +250,8 @@ pub const Material = struct {
         };
 
         self.writer.clear();
-
+        self.writer.write_buffer(0, res.data_buffer, @sizeOf(buffers.Vertex) * cube_index_count, res.data_buffer_offset, c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        
         self.writer.update_set(device, data.material_set);
 
         return data;

--- a/src/engine/scene/scene.zig
+++ b/src/engine/scene/scene.zig
@@ -256,7 +256,12 @@ pub const DrawContext = struct {
 
             c.vkCmdPushConstants(cmd, obj.material.pipeline.layout, c.VK_SHADER_STAGE_VERTEX_BIT, 0, @sizeOf(buffers.GPUDrawPushConstants), &push_constants_mesh);
 
-            c.vkCmdDrawIndexed(cmd, obj.index_count, 1, obj.first_index, 0, 0);
+            if (obj.indirect_buffer) |buffer| {
+                c.vkCmdDrawIndexedIndirect(cmd, buffer, 0, 1, 0);
+            }
+            else {
+                c.vkCmdDrawIndexed(cmd, obj.index_count, 1, obj.first_index, 0, 0);
+            }
 
             stats.drawcall_count += 1;
             stats.triangle_count += obj.index_count / 3;

--- a/src/engine/scene/scene.zig
+++ b/src/engine/scene/scene.zig
@@ -256,8 +256,12 @@ pub const DrawContext = struct {
 
             c.vkCmdPushConstants(cmd, obj.material.pipeline.layout, c.VK_SHADER_STAGE_VERTEX_BIT, 0, @sizeOf(buffers.GPUDrawPushConstants), &push_constants_mesh);
 
+            if (obj.vertex_buffer) |buffer| {
+                c.vkCmdBindVertexBuffers(cmd, 0, 1, &buffer, &obj.vertex_buffer_offset);
+            }
+
             if (obj.indirect_buffer) |buffer| {
-                c.vkCmdDrawIndexedIndirect(cmd, buffer, 0, 1, 0);
+                c.vkCmdDrawIndexedIndirect(cmd, buffer, 0, 1,  @sizeOf(c.VkDrawIndexedIndirectCommand));
             }
             else {
                 c.vkCmdDrawIndexed(cmd, obj.index_count, 1, obj.first_index, 0, 0);

--- a/src/main.zig
+++ b/src/main.zig
@@ -85,7 +85,7 @@ pub fn main() !u8 {
     var current_shader: u32 = 0;
     renderer.bg_shader = background_effects.items[current_shader];
 
-    var current_scene: i32 = 0;
+    var current_scene: i32 = 2;
     var render_scene: i32 = -1;
 
     var reactor_scene: ?levels.ReactorScene = null; 


### PR DESCRIPTION
This pull request introduces significant changes to the rendering pipeline, focusing on improving vertex buffer handling, indirect drawing, and shader updates. Key changes include the addition of vertex and indirect buffers, updates to descriptor bindings, and adjustments to rendering logic to support indirect drawing.

### Rendering Pipeline Enhancements:

* Added a new `vertex_buffer` and `indirect_buffer` to the `RenderObject` struct to support indirect drawing and vertex buffer binding.
* Updated the `DrawContext` to conditionally bind vertex and indirect buffers during rendering. If the indirect buffer is available, it uses `vkCmdDrawIndexedIndirect`; otherwise, it falls back to `vkCmdDrawIndexed`.
* Modified the `Voxel` struct to include the new buffers and updated the draw logic to remove the previous direct draw implementation in favor of indirect drawing.

### Shader Updates:

* Introduced a `readonly buffer` for vertex data in the vertex shader (`cube.vert.glsl`) and replaced the use of push constants for vertex data with this buffer.
* Fixed a logic issue in the compute shader (`world.comp.glsl`) by removing a redundant conditional block that could lead to incorrect index count initialization.
*
### Descriptor and Pipeline Adjustments:

* Added a new binding for the vertex buffer in the material descriptor layout to ensure proper access in shaders.
* Updated the `Material` struct's `write_material` method to write the vertex buffer to the descriptor set.

### Miscellaneous:

* Updated the Vulkan buffer usage flags in `GPUMeshBuffers` to include `VK_BUFFER_USAGE_VERTEX_BUFFER_BIT`, enabling buffers to be used as vertex buffers.
* Changed the default scene in the main application logic to `2` for testing or demonstration purposes.

These changes collectively enhance the flexibility and efficiency of the rendering system, particularly with the introduction of indirect drawing and improved buffer management.